### PR TITLE
fix: containerStyle true blocks render promise from resolving

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -387,17 +387,19 @@ export class MagicMoveRenderer {
       if (this.isFirstRender) {
         this.applyContainerStyle(step)
       }
-      else if (this.checkContainerStyleChanged(step)) {
-        postReflow.push(() => {
-          this.container.classList.add(CLASS_CONTAINER_RESTYLE)
-          this.applyContainerStyle(step)
-        })
+      else {
+        if (this.checkContainerStyleChanged(step)) {
+          postReflow.push(() => {
+            this.container.classList.add(CLASS_CONTAINER_RESTYLE)
+            this.applyContainerStyle(step)
+          })
 
-        promises.push(
-          this.registerTransitionEnd(this.container, () => {
-            this.container.classList.remove(CLASS_CONTAINER_RESTYLE)
-          }),
-        )
+          promises.push(
+            this.registerTransitionEnd(this.container, () => {
+              this.container.classList.remove(CLASS_CONTAINER_RESTYLE)
+            }),
+          )
+        }
       }
     }
 


### PR DESCRIPTION
Closes #8 

I tried with the approach i described in the issue but it didn't work because the promise is created way before the transition actually start.

The only way i can think of to prevent the promise to block if the transition doesn't start is to manually check if the changes will impact the container and avoid pushing the promise at all.

I tested this in stackblitz and it seems to work but if you have any suggestions feel free to guide me.

EDIT: here's the stackblitz with the fix applied (for the wrong behavior look at the issue)

https://stackblitz.com/edit/github-b1z8zy-2mgzpn