### PR TITLE
fix: fake transition blocking events

### DIFF
--- a/playground/src/Playground.vue
+++ b/playground/src/Playground.vue
@@ -149,7 +149,7 @@ function commit() {
 let timer: ReturnType<typeof setTimeout> | undefined
 
 watch(
-  [theme, lang, code, duration, stagger, lineNumbers, rendererContainer, highlighter],
+  [theme, lang, code, duration, stagger, lineNumbers, rendererContainer, highlighter, loadingPromise],
   (n, o) => {
     if (n.every((v, i) => v === o[i]))
       return

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -107,35 +107,6 @@ export class MagicMoveRenderer {
     this.applyNodeStyle(this.container, step)
   }
 
-  private checkContainerStyleChanged(step: KeyedTokensInfo) {
-    if (!this.options.containerStyle)
-      return false
-
-    // we need to clone the node and apply the properties because
-    // if you set the style of backgroundColor=#ffffff and try to access it via
-    // element.style.backgroundColor you get back rgb(255, 255, 255);
-    // this should also be true for other css properties so better be safe than sorry
-    const cloned = this.container.cloneNode() as HTMLElement
-
-    this.applyNodeStyle(cloned, step)
-
-    const bg = cloned.style.backgroundColor !== this.container.style.backgroundColor
-    const fg = cloned.style.color !== this.container.style.color
-    let rootStyle = false
-    if (step.rootStyle) {
-      const items = step.rootStyle.split(';')
-      for (const item of items) {
-        const [key, value] = item.split(':')
-        if (key && value) {
-          rootStyle = rootStyle || this.container.style.getPropertyValue(key.trim()) !== cloned.style.getPropertyValue(key.trim())
-          if (rootStyle)
-            break
-        }
-      }
-    }
-    return bg || fg || rootStyle
-  }
-
   private registerTransitionEnd(el: HTMLElement, cb: () => void) {
     return () => {
       let resolved = false
@@ -390,18 +361,16 @@ export class MagicMoveRenderer {
         this.applyContainerStyle(step)
       }
       else {
-        if (this.checkContainerStyleChanged(step)) {
-          postReflow.push(() => {
-            this.container.classList.add(CLASS_CONTAINER_RESTYLE)
-            this.applyContainerStyle(step)
-          })
+        postReflow.push(() => {
+          this.container.classList.add(CLASS_CONTAINER_RESTYLE)
+          this.applyContainerStyle(step)
+        })
 
-          promises.push(
-            this.registerTransitionEnd(this.container, () => {
-              this.container.classList.remove(CLASS_CONTAINER_RESTYLE)
-            }),
-          )
-        }
+        promises.push(
+          this.registerTransitionEnd(this.container, () => {
+            this.container.classList.remove(CLASS_CONTAINER_RESTYLE)
+          }),
+        )
       }
     }
 


### PR DESCRIPTION
Closes #11 

I tested it locally and everything seems to work fine but please double check, i might be missing some use case. I changed `registerTransitionEnd` to return a function and invoked it after the reflow so that element.getAnimations could have the latest and correct value for every element. After that instead of registering the event i just wait for every css animation finished.

This ensure that if an elements doesn't change because already has the same style the `getAnimations` will not return an animation for that avoiding the the Promise.all at the end to be blocked.