### PR TITLE
feat: support tabindex prop

### DIFF
--- a/src/react/ShikiMagicMove.tsx
+++ b/src/react/ShikiMagicMove.tsx
@@ -13,6 +13,7 @@ export interface ShikiMagicMoveProps {
   onStart?: () => void
   onEnd?: () => void
   className?: string
+  tabindex?: number
 }
 
 export function ShikiMagicMove(props: ShikiMagicMoveProps) {
@@ -44,6 +45,7 @@ export function ShikiMagicMove(props: ShikiMagicMoveProps) {
       ) {
         return machine.current!
       }
+
       return machine.current!.commit(props.code, props.options)
     },
     [props.code, props.options, props.theme, props.lang, lineNumbers],

--- a/src/svelte/ShikiMagicMove.svelte
+++ b/src/svelte/ShikiMagicMove.svelte
@@ -13,6 +13,7 @@
     onStart?: () => void
     onEnd?: () => void
     class?: string
+    tabindex?: number
   }
 
   const { highlighter, lang, theme, code, options, onStart, onEnd, ...props }: ShikiMagicMoveProps = $props()


### PR DESCRIPTION
Elements that can be scrolled horizontally must be accessible from the keyboard.

This is an accessibility requirement.