### PR TITLE
fix: make toggling options re-render in playground (solid)

### DIFF
--- a/playground/src/renderer/solid.tsx
+++ b/playground/src/renderer/solid.tsx
@@ -18,6 +18,7 @@ export const createRendererSolid: RendererFactory = (options): RendererFactoryRe
     const [lang, setLang] = createSignal(props.lang)
     const [theme, setTheme] = createSignal(props.theme)
     const [className, setClassName] = createSignal(props.class)
+    const [options, setOptions] = createSignal(props.options)
 
     createEffect(() => {
       watch(props, () => {
@@ -27,6 +28,7 @@ export const createRendererSolid: RendererFactory = (options): RendererFactoryRe
         setLang(props.lang)
         setTheme(props.theme)
         setClassName(props.class)
+        setOptions(props.options)
       })
     })
 
@@ -38,7 +40,7 @@ export const createRendererSolid: RendererFactory = (options): RendererFactoryRe
           class={className()}
           lang={lang()}
           theme={theme()}
-          options={props.options}
+          options={options()}
         />
       </>
     )


### PR DESCRIPTION
I am unfamiliar with solid, but locally this causes a re-render on the animated side when the options are changed without requiring the user to click the Toggle Examples.
