### PR TITLE
feat: add lit renderer

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -11,6 +11,7 @@ export default defineBuildConfig({
     'src/core',
     'src/types',
     'src/solid',
+    'src/lit',
     'src/renderer',
     {
       builder: 'mkdist',
@@ -55,6 +56,13 @@ export default defineBuildConfig({
         include: ['src/react/**'],
         presets: ['@babel/preset-typescript', '@babel/preset-react'],
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
+      }))
+      plugins.unshift(babel({
+        babelHelpers: 'bundled',
+        include: ['src/lit/**'],
+        presets: ['@babel/preset-typescript'],
+        plugins: [['@babel/plugin-proposal-decorators', { decoratorsBeforeExport: true }], '@babel/plugin-transform-class-properties'],
+        extensions: ['.ts', '.js'],
       }))
     },
     'mkdist:done': async () => {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "play:build": "nr -C playground build"
   },
   "peerDependencies": {
+    "lit": "^3.2.1",
     "react": "^18.2.0",
     "shiki": "^1.1.6",
     "solid-js": "^1.9.1",
@@ -140,6 +141,7 @@
     "eslint-plugin-svelte": "^2.44.1",
     "esno": "^4.8.0",
     "lint-staged": "^15.2.10",
+    "lit": "^3.2.1",
     "pnpm": "^9.12.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,8 @@
     }
   },
   "dependencies": {
+    "@babel/plugin-proposal-decorators": "^7.25.9",
+    "@babel/plugin-transform-class-properties": "^7.25.9",
     "diff-match-patch-es": "^0.1.0",
     "ohash": "^1.1.4"
   },

--- a/playground/src/Playground.vue
+++ b/playground/src/Playground.vue
@@ -7,6 +7,7 @@ import { bundledLanguagesInfo } from 'shiki/langs'
 import { bundledThemesInfo } from 'shiki/themes'
 import { ref, shallowRef, watch } from 'vue'
 import { vueAfter, vueBefore } from './fixture'
+import { createRendererLit } from './renderer/lit'
 import { createRendererReact } from './renderer/react'
 import { createRendererSolid } from './renderer/solid'
 import { createRendererSvelte } from './renderer/svelte.svelte'
@@ -108,6 +109,8 @@ function rendererUpdate() {
       case 'svelte':
         renderer = createRendererSvelte(rendererOptions)
         break
+      case 'lit':
+        renderer = createRendererLit(rendererOptions)
     }
 
     renderer.mount(rendererContainer.value, payload)
@@ -323,6 +326,9 @@ watch(
             </option>
             <option value="svelte">
               Svelte Renderer
+            </option>
+            <option value="lit">
+              Lit Renderer
             </option>
           </select>
         </div>

--- a/playground/src/renderer/lit.ts
+++ b/playground/src/renderer/lit.ts
@@ -1,0 +1,52 @@
+import type { ShikiMagicMove } from '../../../src/lit/ShikiMagicMove'
+import type { RendererFactory, RendererFactoryResult, RendererUpdatePayload } from './types'
+
+import '../../../src/lit/ShikiMagicMove'
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'shiki-magic-move': ShikiMagicMove
+  }
+}
+
+export const createRendererLit: RendererFactory = (options): RendererFactoryResult => {
+  let app: ShikiMagicMove | undefined
+
+  return {
+    mount: (element, payload) => {
+      app = document.createElement('shiki-magic-move')
+
+      app.addEventListener('onStart', options.onStart ?? (() => {}))
+      app.addEventListener('onEnd', options.onEnd ?? (() => {}))
+
+      Object.keys(payload).forEach((prop) => {
+        // eslint-disable-next-line ts/ban-ts-comment
+        // @ts-ignore
+        app[prop as keyof RendererUpdatePayload] = payload[prop as keyof RendererUpdatePayload]
+      })
+
+      element.appendChild(app)
+
+      // eslint-disable-next-line no-console
+      console.log('Lit renderer mounted')
+    },
+
+    update: (payload) => {
+      Object.keys(payload).forEach((prop) => {
+        // eslint-disable-next-line ts/ban-ts-comment
+        // @ts-ignore
+        app[prop as keyof RendererUpdatePayload] = payload[prop as keyof RendererUpdatePayload]
+      })
+    },
+
+    dispose: () => {
+      if (!app)
+        return
+      app.remove()
+      app = undefined
+
+      // eslint-disable-next-line no-console
+      console.log('Lit renderer disposed')
+    },
+  }
+}

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ESNext",
     "jsx": "preserve",
     "lib": ["ESNext", "DOM"],
+    "useDefineForClassFields": false,
+    "experimentalDecorators": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       lint-staged:
         specifier: ^15.2.10
         version: 15.2.10
+      lit:
+        specifier: ^3.2.1
+        version: 3.2.1
       pnpm:
         specifier: ^9.12.1
         version: 9.12.1
@@ -1173,6 +1176,12 @@ packages:
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
     engines: {node: '>=10'}
 
+  '@lit-labs/ssr-dom-shim@1.2.1':
+    resolution: {integrity: sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==}
+
+  '@lit/reactive-element@2.0.4':
+    resolution: {integrity: sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1287,46 +1296,55 @@ packages:
     resolution: {integrity: sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.24.0':
     resolution: {integrity: sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.24.0':
     resolution: {integrity: sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.24.0':
     resolution: {integrity: sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
     resolution: {integrity: sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.24.0':
     resolution: {integrity: sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.24.0':
     resolution: {integrity: sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.24.0':
     resolution: {integrity: sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.24.0':
     resolution: {integrity: sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.24.0':
     resolution: {integrity: sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==}
@@ -1432,6 +1450,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2956,6 +2977,15 @@ packages:
   listr2@8.2.4:
     resolution: {integrity: sha512-opevsywziHd3zHCVQGAj8zu+Z3yHNkkoYhWIGnq54RrCVwLz0MozotJEDnKsIBLvkfLGN6BLOyAeRrYI0pKA4g==}
     engines: {node: '>=18.0.0'}
+
+  lit-element@4.1.1:
+    resolution: {integrity: sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==}
+
+  lit-html@3.2.1:
+    resolution: {integrity: sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==}
+
+  lit@3.2.1:
+    resolution: {integrity: sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -5128,6 +5158,12 @@ snapshots:
       string-argv: 0.3.2
       type-detect: 4.0.8
 
+  '@lit-labs/ssr-dom-shim@1.2.1': {}
+
+  '@lit/reactive-element@2.0.4':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.2.1
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5386,6 +5422,8 @@ snapshots:
       csstype: 3.1.3
 
   '@types/resolve@1.20.2': {}
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
 
@@ -7316,6 +7354,22 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
+
+  lit-element@4.1.1:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.2.1
+      '@lit/reactive-element': 2.0.4
+      lit-html: 3.2.1
+
+  lit-html@3.2.1:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.2.1:
+    dependencies:
+      '@lit/reactive-element': 2.0.4
+      lit-element: 4.1.1
+      lit-html: 3.2.1
 
   load-tsconfig@0.2.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@babel/plugin-proposal-decorators':
+        specifier: ^7.25.9
+        version: 7.25.9(@babel/core@7.25.2)
+      '@babel/plugin-transform-class-properties':
+        specifier: ^7.25.9
+        version: 7.25.9(@babel/core@7.25.2)
       diff-match-patch-es:
         specifier: ^0.1.0
         version: 0.1.0
@@ -235,6 +241,10 @@ packages:
     resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.25.2':
     resolution: {integrity: sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==}
     engines: {node: '>=6.9.0'}
@@ -251,8 +261,16 @@ packages:
     resolution: {integrity: sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.26.2':
+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-annotate-as-pure@7.25.7':
     resolution: {integrity: sha512-4xwU8StnqnlIhhioZf1tqnVWeQ9pvH/ujS8hRfw/WOza+/a+1qv69BWNy+oY231maTCWgKWhfBU7kDpsds6zAA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.25.9':
+    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.25.2':
@@ -265,8 +283,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-create-class-features-plugin@7.25.9':
+    resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-member-expression-to-functions@7.25.7':
     resolution: {integrity: sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.25.9':
+    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.18.6':
@@ -297,20 +325,26 @@ packages:
     resolution: {integrity: sha512-VAwcwuYhv/AT+Vfr28c9y6SHzTan1ryqrydSTFGjU0uDJHw3uZ+PduI8plCLkRsDnqK2DMEDmwrOQRsK/Ykjng==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-plugin-utils@7.24.7':
-    resolution: {integrity: sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-plugin-utils@7.24.8':
-    resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
+  '@babel/helper-optimise-call-expression@7.25.9':
+    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.25.7':
     resolution: {integrity: sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-plugin-utils@7.25.9':
+    resolution: {integrity: sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-replace-supers@7.25.7':
     resolution: {integrity: sha512-iy8JhqlUW9PtZkd4pHM96v6BdJ66Ba9yWSE4z0W4TvSZwLBPkyDsiIU3ENe4SmrzRBs76F7rQXTy1lYC49n6Lw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-replace-supers@7.25.9':
+    resolution: {integrity: sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -327,6 +361,10 @@ packages:
     resolution: {integrity: sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
+    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.24.8':
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
@@ -335,12 +373,20 @@ packages:
     resolution: {integrity: sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.7':
     resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.24.8':
@@ -373,6 +419,23 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.26.2':
+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-proposal-decorators@7.25.9':
+    resolution: {integrity: sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.25.9':
+    resolution: {integrity: sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-syntax-jsx@7.24.7':
     resolution: {integrity: sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==}
     engines: {node: '>=6.9.0'}
@@ -387,6 +450,12 @@ packages:
 
   '@babel/plugin-syntax-typescript@7.25.7':
     resolution: {integrity: sha512-rR+5FDjpCHqqZN2bzZm18bVYGaejGq5ZkpVCJLXor/+zlSrSoc4KWcHI0URVWjl/68Dyr1uwZUz/1njycEAv9g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-class-properties@7.25.9':
+    resolution: {integrity: sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -463,6 +532,10 @@ packages:
     resolution: {integrity: sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.25.9':
+    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.25.3':
     resolution: {integrity: sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==}
     engines: {node: '>=6.9.0'}
@@ -471,12 +544,20 @@ packages:
     resolution: {integrity: sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.25.9':
+    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.25.8':
     resolution: {integrity: sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.0':
+    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
   '@clack/core@0.3.4':
@@ -4308,6 +4389,12 @@ snapshots:
       '@babel/highlight': 7.25.7
       picocolors: 1.1.0
 
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.0
+
   '@babel/compat-data@7.25.2': {}
 
   '@babel/core@7.25.2':
@@ -4339,7 +4426,15 @@ snapshots:
 
   '@babel/generator@7.25.7':
     dependencies:
-      '@babel/types': 7.25.8
+      '@babel/types': 7.26.0
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
+
+  '@babel/generator@7.26.2':
+    dependencies:
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
@@ -4347,6 +4442,10 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.25.7':
     dependencies:
       '@babel/types': 7.25.8
+
+  '@babel/helper-annotate-as-pure@7.25.9':
+    dependencies:
+      '@babel/types': 7.26.0
 
   '@babel/helper-compilation-targets@7.25.2':
     dependencies:
@@ -4369,10 +4468,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.25.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/traverse': 7.25.9
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-member-expression-to-functions@7.25.7':
     dependencies:
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.25.9
       '@babel/types': 7.25.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-member-expression-to-functions@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4400,7 +4519,7 @@ snapshots:
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.3
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -4418,25 +4537,36 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.8
 
-  '@babel/helper-plugin-utils@7.24.7': {}
-
-  '@babel/helper-plugin-utils@7.24.8': {}
+  '@babel/helper-optimise-call-expression@7.25.9':
+    dependencies:
+      '@babel/types': 7.26.0
 
   '@babel/helper-plugin-utils@7.25.7': {}
+
+  '@babel/helper-plugin-utils@7.25.9': {}
 
   '@babel/helper-replace-supers@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-member-expression-to-functions': 7.25.7
-      '@babel/helper-optimise-call-expression': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
-      '@babel/traverse': 7.25.3
-      '@babel/types': 7.25.6
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4454,13 +4584,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.24.8': {}
 
   '@babel/helper-string-parser@7.25.7': {}
 
+  '@babel/helper-string-parser@7.25.9': {}
+
   '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/helper-validator-identifier@7.25.7': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-option@7.24.8': {}
 
@@ -4480,7 +4621,7 @@ snapshots:
 
   '@babel/highlight@7.25.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.7
+      '@babel/helper-validator-identifier': 7.25.9
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.0
@@ -4493,10 +4634,28 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.8
 
+  '@babel/parser@7.26.2':
+    dependencies:
+      '@babel/types': 7.26.0
+
+  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-jsx@7.25.7(@babel/core@7.25.2)':
     dependencies:
@@ -4506,7 +4665,15 @@ snapshots:
   '@babel/plugin-syntax-typescript@7.25.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.25.7
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-modules-commonjs@7.25.7(@babel/core@7.25.2)':
     dependencies:
@@ -4532,12 +4699,12 @@ snapshots:
   '@babel/plugin-transform-react-jsx-self@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-react-jsx-source@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-react-jsx@7.25.7(@babel/core@7.25.2)':
     dependencies:
@@ -4602,7 +4769,13 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.25.7
       '@babel/parser': 7.25.8
-      '@babel/types': 7.25.8
+      '@babel/types': 7.26.0
+
+  '@babel/template@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
 
   '@babel/traverse@7.25.3':
     dependencies:
@@ -4628,6 +4801,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/parser': 7.26.2
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
+      debug: 4.3.7
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.25.6':
     dependencies:
       '@babel/helper-string-parser': 7.24.8
@@ -4639,6 +4824,11 @@ snapshots:
       '@babel/helper-string-parser': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
+
+  '@babel/types@7.26.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@clack/core@0.3.4':
     dependencies:
@@ -7923,7 +8113,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4

--- a/src/lit.ts
+++ b/src/lit.ts
@@ -1,0 +1,1 @@
+export * from './lit'

--- a/src/lit.ts
+++ b/src/lit.ts
@@ -1,1 +1,1 @@
-export * from './lit'
+export * from './lit/index'

--- a/src/lit/ShikiMagicMove.ts
+++ b/src/lit/ShikiMagicMove.ts
@@ -9,7 +9,7 @@ import './ShikiMagicMoveRenderer'
 @customElement('shiki-magic-move')
 export class ShikiMagicMove extends LitElement {
   @property()
-  highlighter?: HighlighterCore
+  highlighter!: HighlighterCore
 
   @property()
   lang: string = 'typescript'
@@ -53,7 +53,7 @@ export class ShikiMagicMove extends LitElement {
     if (!this.hasUpdated) {
       this.machine = createMagicMoveMachine(
         code => codeToKeyedTokens(
-          this.highlighter as HighlighterCore,
+          this.highlighter,
           code,
           {
             lang: this.lang,

--- a/src/lit/ShikiMagicMove.ts
+++ b/src/lit/ShikiMagicMove.ts
@@ -1,0 +1,107 @@
+import type { Ref } from 'lit/directives/ref.js'
+import type { HighlighterCore } from 'shiki/core'
+import type { KeyedTokensInfo, MagicMoveDifferOptions, MagicMoveRenderOptions } from '../types'
+import { html, LitElement } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+import { createRef, ref } from 'lit/directives/ref.js'
+import { codeToKeyedTokens, createMagicMoveMachine } from '../core'
+import { MagicMoveRenderer as Renderer } from '../renderer'
+
+@customElement('shiki-magic-move')
+export class ShikiMagicMove extends LitElement {
+  @property()
+  highlighter?: HighlighterCore
+
+  @property()
+  lang: string = 'typescript'
+
+  @property()
+  theme: string = 'github-light'
+
+  @property()
+  code: string = ''
+
+  @property()
+  class: string = ''
+
+  @property()
+  options?: MagicMoveRenderOptions & MagicMoveDifferOptions
+
+  machine?: {
+    commit: (code: string, override?: MagicMoveDifferOptions) => {
+      current: KeyedTokensInfo
+      previous: KeyedTokensInfo
+    }
+  }
+
+  result?: { current: KeyedTokensInfo, previous: KeyedTokensInfo }
+
+  container: Ref<HTMLPreElement> = createRef()
+
+  renderer?: Renderer
+
+  get tokens() {
+    return this.result?.current
+  }
+
+  get previous() {
+    return this.result?.previous
+  }
+
+  createRenderRoot() {
+    // Disable shadow DOM.
+    return this
+  }
+
+  getResult() {
+    this.result = this.machine?.commit(this.code, this.options)
+  }
+
+  firstUpdated() {
+    this.renderer = new Renderer(this.container.value!)
+    this.machine = createMagicMoveMachine(
+      code => codeToKeyedTokens(
+        this.highlighter as HighlighterCore,
+        code,
+        {
+          lang: this.lang,
+          theme: this.theme,
+        },
+        this.options?.lineNumbers,
+      ),
+      this.options,
+    )
+    this.getResult()
+    if (this.tokens)
+      this.renderer?.render(this.tokens)
+  }
+
+  async playAnimation() {
+    if (this.renderer) {
+      if (this.previous)
+        this.renderer.replace(this.previous)
+      this.dispatchEvent(new CustomEvent('onStart'))
+      if (this.tokens)
+        await this.renderer?.render(this.tokens)
+      this.dispatchEvent(new CustomEvent('onEnd'))
+    }
+  }
+
+  shouldUpdate(changedProperties: Map<string, any>) {
+    // Check for whether it's the first time rendering.
+    if (this.hasUpdated) {
+      this.getResult()
+      if (this.renderer) {
+        if (changedProperties.has('options'))
+          Object.assign(this.renderer?.options, changedProperties.get('options'))
+        this.playAnimation()
+        return false
+      }
+    }
+    return true
+  }
+
+  render() {
+    return html`<pre ${ref(this.container)} class="shiki-magic-move-container ${this.class}"></pre>`
+  }
+}

--- a/src/lit/ShikiMagicMove.ts
+++ b/src/lit/ShikiMagicMove.ts
@@ -1,11 +1,10 @@
-import type { Ref } from 'lit/directives/ref.js'
 import type { HighlighterCore } from 'shiki/core'
 import type { KeyedTokensInfo, MagicMoveDifferOptions, MagicMoveRenderOptions } from '../types'
 import { html, LitElement } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
-import { createRef, ref } from 'lit/directives/ref.js'
 import { codeToKeyedTokens, createMagicMoveMachine } from '../core'
-import { MagicMoveRenderer as Renderer } from '../renderer'
+
+import './ShikiMagicMoveRenderer'
 
 @customElement('shiki-magic-move')
 export class ShikiMagicMove extends LitElement {
@@ -36,10 +35,6 @@ export class ShikiMagicMove extends LitElement {
 
   result?: { current: KeyedTokensInfo, previous: KeyedTokensInfo }
 
-  container: Ref<HTMLPreElement> = createRef()
-
-  renderer?: Renderer
-
   get tokens() {
     return this.result?.current
   }
@@ -53,55 +48,34 @@ export class ShikiMagicMove extends LitElement {
     return this
   }
 
-  getResult() {
-    this.result = this.machine?.commit(this.code, this.options)
-  }
-
-  firstUpdated() {
-    this.renderer = new Renderer(this.container.value!)
-    this.machine = createMagicMoveMachine(
-      code => codeToKeyedTokens(
-        this.highlighter as HighlighterCore,
-        code,
-        {
-          lang: this.lang,
-          theme: this.theme,
-        },
-        this.options?.lineNumbers,
-      ),
-      this.options,
-    )
-    this.getResult()
-    if (this.tokens)
-      this.renderer?.render(this.tokens)
-  }
-
-  async playAnimation() {
-    if (this.renderer) {
-      if (this.previous)
-        this.renderer.replace(this.previous)
-      this.dispatchEvent(new CustomEvent('onStart'))
-      if (this.tokens)
-        await this.renderer?.render(this.tokens)
-      this.dispatchEvent(new CustomEvent('onEnd'))
-    }
-  }
-
-  shouldUpdate(changedProperties: Map<string, any>) {
+  shouldUpdate() {
     // Check for whether it's the first time rendering.
-    if (this.hasUpdated) {
-      this.getResult()
-      if (this.renderer) {
-        if (changedProperties.has('options'))
-          Object.assign(this.renderer?.options, changedProperties.get('options'))
-        this.playAnimation()
-        return false
-      }
+    if (!this.hasUpdated) {
+      this.machine = createMagicMoveMachine(
+        code => codeToKeyedTokens(
+          this.highlighter as HighlighterCore,
+          code,
+          {
+            lang: this.lang,
+            theme: this.theme,
+          },
+          this.options?.lineNumbers,
+        ),
+        this.options,
+      )
     }
     return true
   }
 
   render() {
-    return html`<pre ${ref(this.container)} class="shiki-magic-move-container ${this.class}"></pre>`
+    this.result = this.machine?.commit(this.code, this.options)
+    return html`<shiki-magic-move-renderer
+      .tokens=${this.tokens}
+      .previous=${this.previous}
+      .options=${this.options}
+      .class=${this.class}
+      @onStart=${() => this.dispatchEvent(new CustomEvent('onStart'))}
+      @onEnd=${() => this.dispatchEvent(new CustomEvent('onEnd'))}
+    ></shiki-magic-move-renderer>`
   }
 }

--- a/src/lit/ShikiMagicMovePrecompiled.ts
+++ b/src/lit/ShikiMagicMovePrecompiled.ts
@@ -1,0 +1,46 @@
+import type { KeyedTokensInfo, MagicMoveDifferOptions, MagicMoveRenderOptions } from '../types'
+import { html, LitElement } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+import { syncTokenKeys, toKeyedTokens } from '../core'
+
+import './ShikiMagicMoveRenderer'
+
+@customElement('shiki-magic-move-precompiled')
+export class ShikiMagicMovePrecompiled extends LitElement {
+  @property()
+  steps: KeyedTokensInfo[] = []
+
+  @property()
+  step: number = 0
+
+  @property()
+  animated: boolean = true
+
+  @property()
+  options?: MagicMoveRenderOptions & MagicMoveDifferOptions
+
+  previous: KeyedTokensInfo = toKeyedTokens('', [])
+
+  createRenderRoot() {
+    // Disable shadow DOM.
+    return this
+  }
+
+  render() {
+    const result = syncTokenKeys(
+      this.previous,
+      this.steps[Math.min(this.step, this.steps.length - 1)],
+      this.options,
+    )
+    this.previous = result.to
+
+    return html`<shiki-magic-move-renderer
+      .tokens=${result.to}
+      .previous=${result.from}
+      .options=${this.options}
+      .animate=${this.animated}
+      @onStart=${() => this.dispatchEvent(new CustomEvent('onStart'))}
+      @onEnd=${() => this.dispatchEvent(new CustomEvent('onEnd'))}
+    ></shiki-magic-move-renderer>`
+  }
+}

--- a/src/lit/ShikiMagicMoveRenderer.ts
+++ b/src/lit/ShikiMagicMoveRenderer.ts
@@ -1,0 +1,71 @@
+import type { Ref } from 'lit/directives/ref.js'
+import type { KeyedTokensInfo, MagicMoveRenderOptions } from '../types'
+import { html, LitElement } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+import { createRef, ref } from 'lit/directives/ref.js'
+import { MagicMoveRenderer as Renderer } from '../renderer'
+
+@customElement('shiki-magic-move-renderer')
+export class ShikiMagicMoveRenderer extends LitElement {
+  @property()
+  animated: boolean = true
+
+  @property()
+  tokens?: KeyedTokensInfo
+
+  @property()
+  previous?: KeyedTokensInfo
+
+  @property()
+  options?: MagicMoveRenderOptions
+
+  @property()
+  class: string = ''
+
+  container: Ref<HTMLPreElement> = createRef()
+
+  renderer?: Renderer
+
+  createRenderRoot() {
+    // Disable shadow DOM.
+    return this
+  }
+
+  async transform() {
+    if (this.renderer) {
+      if (this.animated) {
+        if (this.previous)
+          this.renderer.replace(this.previous)
+        this.dispatchEvent(new CustomEvent('onStart'))
+        if (this.tokens)
+          await this.renderer?.render(this.tokens)
+        this.dispatchEvent(new CustomEvent('onEnd'))
+      }
+      else if (this.tokens) {
+        this.renderer.replace(this.tokens)
+      }
+    }
+  }
+
+  shouldUpdate(changedProperties: Map<string, any>) {
+    if (this.hasUpdated) {
+      if (this.renderer) {
+        if (changedProperties.has('options'))
+          Object.assign(this.renderer?.options, changedProperties.get('options'))
+        this.transform()
+        return false
+      }
+    }
+    return true
+  }
+
+  firstUpdated() {
+    this.renderer = new Renderer(this.container.value!)
+    if (this.tokens)
+      this.renderer?.render(this.tokens)
+  }
+
+  render() {
+    return html`<pre ${ref(this.container)} class="shiki-magic-move-container ${this.class}"></pre>`
+  }
+}

--- a/src/lit/ShikiMagicMoveRenderer.ts
+++ b/src/lit/ShikiMagicMoveRenderer.ts
@@ -11,7 +11,7 @@ export class ShikiMagicMoveRenderer extends LitElement {
   animated: boolean = true
 
   @property()
-  tokens?: KeyedTokensInfo
+  tokens!: KeyedTokensInfo
 
   @property()
   previous?: KeyedTokensInfo
@@ -37,11 +37,10 @@ export class ShikiMagicMoveRenderer extends LitElement {
         if (this.previous)
           this.renderer.replace(this.previous)
         this.dispatchEvent(new CustomEvent('onStart'))
-        if (this.tokens)
-          await this.renderer?.render(this.tokens)
+        await this.renderer?.render(this.tokens)
         this.dispatchEvent(new CustomEvent('onEnd'))
       }
-      else if (this.tokens) {
+      else {
         this.renderer.replace(this.tokens)
       }
     }
@@ -61,8 +60,7 @@ export class ShikiMagicMoveRenderer extends LitElement {
 
   firstUpdated() {
     this.renderer = new Renderer(this.container.value!)
-    if (this.tokens)
-      this.renderer?.render(this.tokens)
+    this.renderer?.render(this.tokens)
   }
 
   render() {

--- a/src/lit/index.ts
+++ b/src/lit/index.ts
@@ -1,2 +1,3 @@
 export { ShikiMagicMove } from './ShikiMagicMove'
+export { ShikiMagicMovePrecompiled } from './ShikiMagicMovePrecompiled'
 export { ShikiMagicMoveRenderer } from './ShikiMagicMoveRenderer'

--- a/src/lit/index.ts
+++ b/src/lit/index.ts
@@ -1,0 +1,1 @@
+export { ShikiMagicMove } from './ShikiMagicMove'

--- a/src/lit/index.ts
+++ b/src/lit/index.ts
@@ -1,1 +1,2 @@
 export { ShikiMagicMove } from './ShikiMagicMove'
+export { ShikiMagicMoveRenderer } from './ShikiMagicMoveRenderer'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ESNext",
     "jsx": "preserve",
     "lib": ["ESNext", "DOM"],
+    "useDefineForClassFields": false,
+    "experimentalDecorators": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
#33 

I made the shiki-magic-move web component using lit element, in order to make it available for vanilla js as well

But I ran into a problem that it doesn't work after building 🤔 here is my building config code

``` ts
plugins.unshift(babel({
  babelHelpers: 'bundled',
  include: ['src/lit/**'],
  presets: ['@babel/preset-typescript'],
  plugins: [['@babel/plugin-proposal-decorators', { decoratorsBeforeExport: true }], '@babel/plugin-transform-class-properties'],
  extensions: ['.ts', '.js'],
}))
```