### PR TITLE
reproduction for #39

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="/precompiled.tsx"></script>
   </body>
 </html>

--- a/playground/precompiled.tsx
+++ b/playground/precompiled.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client"
+import { createHighlighter } from 'shiki'
+import { ShikiMagicMovePrecompiled } from "../src/react";
+import { createMagicMoveMachine } from "../src/core";
+import { codeToKeyedTokens } from "../src/core";
+import '../src/style.css'
+
+const highlighter = await createHighlighter({
+    themes: ["vitesse-light"],
+    langs: ["tsx"],
+})
+
+const machine = createMagicMoveMachine(
+    code => codeToKeyedTokens(highlighter, code, {
+        lang: "tsx",
+        theme: "vitesse-light",
+    })
+)
+
+const compiledCode = [
+`function greet() {
+    console.log('Hello, World!');
+}
+
+greet();`,
+`const name = 'Alice';
+
+function greet() {
+    console.log('Hello, ' + name + '!');
+}
+
+greet();`
+].map(code => machine.commit(code).current)
+
+
+const CodePage: React.FC = () => {
+    const [step, setStep] = useState(0)
+
+    return <>
+        <ShikiMagicMovePrecompiled
+            steps={compiledCode}
+            step={step}
+            animate={true}
+            options={{ duration: 750, stagger: 7, lineNumbers: true }}
+        />
+        <button onClick={() => setStep(step === 1 ? 0 : 1)}>Animate</button>
+    </>
+}
+
+createRoot(document.getElementById('app')!).render(<CodePage/>)

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
       'shiki-magic-move/renderer': fileURLToPath(new URL('../src/renderer.ts', import.meta.url)),
     },
   },
+  server: {
+    allowedHosts: true
+  },
   plugins: [
     Vue(),
     UnoCSS(),


### PR DESCRIPTION
- Reproduction for #39 added to the playground to remove unnecessary factors
- [x] precompiler machine created using `createMagicMoveMachine` and `codeToKeyedTokens`
- [x] compiled using `machine.commit(code).current` 
- [x] compiled array passed to  `ShikiMagicMovePrecompiled` using `steps` prop
- [x] toggled the selected `step` using `useState`  