### PR TITLE
fix: broken animation with react precompiled (#39)

### DIFF
--- a/src/react/ShikiMagicMovePrecompiled.tsx
+++ b/src/react/ShikiMagicMovePrecompiled.tsx
@@ -28,17 +28,17 @@ export function ShikiMagicMovePrecompiled(
     onEnd,
   }: ShikiMagicMovePrecompiledProps,
 ) {
-  const [previous, setPrevious] = React.useState(EMPTY)
+  const previousRef = React.useRef(EMPTY)
 
   const result = React.useMemo(() => {
     const res = syncTokenKeys(
-      previous,
+      previousRef.current,
       steps[Math.min(step, steps.length - 1)],
       options,
     )
-    setPrevious(res.to)
+    previousRef.current = res.to
     return res
-  }, [previous, steps, step, options])
+  }, [steps, step, options])
 
   return (
     <ShikiMagicMoveRenderer


### PR DESCRIPTION
Use ref instead of state to avoid unnecessary rerenders.

Fixes #39 