### PR TITLE
fix: align line numbers

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -79,7 +79,7 @@ export function toKeyedTokens(
   const hash = getHash(code + salt)
   let lastOffset = 0
   let firstOffset = 0
-  const lineNumberDigits = Math.ceil(Math.log10(tokens.length))
+  const lineNumberDigits = Math.max(1, String(tokens.length).length)
   const keyed = splitWhitespaceTokens(tokens)
     .flatMap((line, lineIdx): ThemedToken[] => {
       firstOffset = line[0]?.offset || lastOffset


### PR DESCRIPTION
## Summary

Adjust line number digit calculation to use the max line count length, so 1–9 lines get a leading space for alignment.

<img width="1512" height="895" alt="image" src="https://github.com/user-attachments/assets/8eb5fe4b-cee1-4bec-9009-37874e97cff6" />

solve issue: https://github.com/shikijs/shiki-magic-move/issues/44